### PR TITLE
Staking tab on account page

### DIFF
--- a/src/app/pages/network/explorer/account/account-detail/account-detail.component.html
+++ b/src/app/pages/network/explorer/account/account-detail/account-detail.component.html
@@ -422,7 +422,9 @@
 
     <mat-tab label="Staking">
       <ng-container *ngIf="id | async as address">
-        <app-account-events [address]="address" [listSize]="listsSize" [eventTypes]="{'Staking': ['Rewarded']}" [columns]="['icon', 'age', 'event', 'amount', 'details']"></app-account-events>
+        <app-account-events [address]="address" [listSize]="listsSize"
+                            [eventTypes]="{'Staking': ['Bonded', 'Chilled', 'Kicked', 'Rewarded', 'Slashed', 'Unbonded', 'Withdrawn']}"
+                            [columns]="['icon', 'age', 'event', 'amount', 'details']"></app-account-events>
       </ng-container>
     </mat-tab>
   </mat-tab-group>

--- a/src/app/pages/network/explorer/account/account-detail/account-detail.component.html
+++ b/src/app/pages/network/explorer/account/account-detail/account-detail.component.html
@@ -164,7 +164,6 @@
         </table>
       </ng-container>
 
-
       <ng-container *ngIf="$any((accountBalances | async)) as balances">
         <h3>Balances</h3>
         <table class="detail-table">
@@ -419,6 +418,12 @@
         <tr mat-row *matRowDef="let myRowData; columns: balanceTransferColumns"></tr>
 
       </table>
+    </mat-tab>
+
+    <mat-tab label="Staking">
+      <ng-container *ngIf="id | async as address">
+        <app-account-events [address]="address" [listSize]="listsSize" [eventTypes]="{'Staking': ['Rewarded']}" [columns]="['icon', 'age', 'event', 'amount', 'details']"></app-account-events>
+      </ng-container>
     </mat-tab>
   </mat-tab-group>
 

--- a/src/app/pages/network/explorer/account/account-detail/account-events/account-events.component.html
+++ b/src/app/pages/network/explorer/account/account-detail/account-events/account-events.component.html
@@ -1,5 +1,7 @@
+<ng-container *ngIf="(networkProperties | async) as props">
+
 <mat-toolbar *ngIf="address">
-  <button mat-stroked-button [routerLink]="'../../event'" [queryParams]="{'address': address}">
+  <button mat-stroked-button [routerLink]="'../../event'" [queryParams]="queryParams | async">
     Open Events List
   </button>
 </mat-toolbar>
@@ -49,9 +51,19 @@
   </ng-container>
 
   <ng-container matColumnDef="attribute">
-    <th mat-header-cell *matHeaderCellDef>Attribute</th>
+    <th mat-header-cell *matHeaderCellDef>Attribute With Account</th>
     <td mat-cell *matCellDef="let event">
       {{event.attributeName}}
+    </td>
+  </ng-container>
+
+  <ng-container matColumnDef="amount">
+    <th mat-header-cell *matHeaderCellDef>Amount</th>
+    <td mat-cell *matCellDef="let event">
+      <ng-container *ngFor="let nameAndAmount of getAmountsFromAttributes(event.attributes)">
+        <ng-container *ngIf="nameAndAmount[0] !== 'amount'">{{nameAndAmount[0]}}:</ng-container>
+        <balance [value]="nameAndAmount[1]" [tokenSymbol]="props.tokenSymbol" [tokenDecimals]="props.tokenDecimals"></balance><br>
+      </ng-container>
     </td>
   </ng-container>
 
@@ -62,7 +74,9 @@
     </td>
   </ng-container>
 
-  <tr mat-header-row *matHeaderRowDef="eventsColumns; sticky: true"></tr>
-  <tr mat-row *matRowDef="let myRowData; columns: eventsColumns"></tr>
+  <tr mat-header-row *matHeaderRowDef="columns; sticky: true"></tr>
+  <tr mat-row *matRowDef="let myRowData; columns: columns"></tr>
 
 </table>
+
+</ng-container>

--- a/src/app/pages/network/explorer/account/account-detail/account-events/account-events.component.ts
+++ b/src/app/pages/network/explorer/account/account-detail/account-events/account-events.component.ts
@@ -79,9 +79,8 @@ export class AccountEventsComponent implements OnChanges, OnDestroy {
     this.fetchAndSubscribeEvents(address);
     const queryParams: {[p: string]: string} = {'address': address};
     if (this.eventTypes) {
-      for (let [pallet, eventNames] of Object.entries(this.eventTypes)) {
+      for (let pallet of Object.keys(this.eventTypes)) {
         queryParams.pallet = pallet;
-        queryParams.eventName = eventNames[0];
       }
     }
     this.queryParams.next(queryParams);
@@ -94,13 +93,7 @@ export class AccountEventsComponent implements OnChanges, OnDestroy {
     }
 
     const idHex: string = u8aToHex(decodeAddress(address));
-    const filterParams: any = {};
-    if (this.eventTypes) {
-      for (let [pallet, eventNames] of Object.entries(this.eventTypes)) {
-        filterParams.pallet = pallet;
-        filterParams.eventName = eventNames[0];
-      }
-    }
+    const filterParams: any = {eventTypes: this.eventTypes};
 
     const events = await this.pa.run().polkascan.chain.getEventsByAccount(idHex, filterParams, this.listSize);
 

--- a/src/app/pages/network/explorer/event/event-list/event-list.component.html
+++ b/src/app/pages/network/explorer/event/event-list/event-list.component.html
@@ -78,6 +78,7 @@
   </button>
 </div>
 
+<ng-container *ngIf="(networkProperties | async) as props">
 <ng-container *ngIf="(itemsObservable | async) as dataSource">
   <table mat-table [dataSource]="dataSource" [trackBy]="track">
 
@@ -124,9 +125,19 @@
     </ng-container>
 
     <ng-container matColumnDef="attribute" *ngIf="addressControl.value">
-      <th mat-header-cell *matHeaderCellDef>Attribute</th>
+      <th mat-header-cell *matHeaderCellDef>Attribute With Account</th>
       <td mat-cell *matCellDef="let event">
         {{event.attributeName}}
+      </td>
+    </ng-container>
+
+    <ng-container matColumnDef="amount">
+      <th mat-header-cell *matHeaderCellDef>Amount</th>
+      <td mat-cell *matCellDef="let event">
+        <ng-container *ngFor="let nameAndAmount of getAmountsFromAttributes(event.attributes)">
+          <ng-container *ngIf="nameAndAmount[0] !== 'amount'">{{nameAndAmount[0]}}:</ng-container>
+          <balance [value]="nameAndAmount[1]" [tokenSymbol]="props.tokenSymbol" [tokenDecimals]="props.tokenDecimals"></balance><br>
+        </ng-container>
       </td>
     </ng-container>
 
@@ -153,6 +164,7 @@
     </ng-container>
   </div>
 
+</ng-container>
 </ng-container>
 
 <div *ngIf="loadingObservable | async">

--- a/src/app/pages/network/explorer/event/event-list/event-list.component.ts
+++ b/src/app/pages/network/explorer/event/event-list/event-list.component.ts
@@ -62,8 +62,8 @@ export class EventListComponent extends PaginatedListComponentBase<pst.Event | p
     address: this.addressControl,
   });
 
-  visibleColumns = ['icon', 'eventID', 'age', 'referencedTransaction', 'pallet', 'event', 'details'];
-  visibleColumnsForAccount = ['icon', 'eventID', 'age', 'referencedTransaction', 'pallet', 'event', 'attribute', 'details'];
+  visibleColumns = ['icon', 'eventID', 'age', 'referencedTransaction', 'pallet', 'event', 'amount', 'details'];
+  visibleColumnsForAccount = ['icon', 'eventID', 'age', 'referencedTransaction', 'pallet', 'event', 'attribute', 'amount', 'details'];
 
   constructor(private ns: NetworkService,
               private pa: PolkadaptService,
@@ -359,5 +359,18 @@ export class EventListComponent extends PaginatedListComponentBase<pst.Event | p
 
   track(i: any, event: pst.Event | pst.AccountEvent): string {
     return `${event.blockNumber}-${event.eventIdx}`;
+  }
+
+
+  getAmountsFromAttributes(data: string): [string, number][] {
+    const attrNames = ['amount', 'actual_fee', 'tip'];
+    const amounts: [string, number][] = [];
+    for (let name of attrNames) {
+      const match = new RegExp(`"${name}": (\\d+)`).exec(data);
+      if (match) {
+        amounts.push([name, parseInt(match[1], 10)]);
+      }
+    }
+    return amounts;
   }
 }


### PR DESCRIPTION
Show a new tab on the account page that shows a list of recent staking rewards and slashes.

- [x] Show rewards with amounts
- [x] Show slashes with amounts. This needs an update to the Filter in the GraphQL API, to be able to filter on multiple values ('in' filter).
- [x] Show button to navigate to the complete list of rewards and slashes on the Events page.